### PR TITLE
Chrome extension ai artist finder

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react"
 
-const BACKEND_URL = "https://a-imusic-assistant.vercel.app/"
+const BACKEND_URL = "https://ai-music-assistant.vercel.app/api/query"
 
 export default function App() {
   const [messages, setMessages] = useState([


### PR DESCRIPTION
Correct backend URL in `src/App.jsx` to point to the correct Vercel endpoint.

The previous URL was misspelled, preventing the Chrome extension from communicating with the AI assistant backend. This fix enables the extension to properly query the Gemini API.

---
<a href="https://cursor.com/background-agent?bcId=bc-43e733af-52a4-464e-887d-03b7dddcb604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43e733af-52a4-464e-887d-03b7dddcb604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

