### PR TITLE
Debug vercel api method not allowed error

### DIFF
--- a/api/query.js
+++ b/api/query.js
@@ -4,27 +4,75 @@ export const config = { runtime: "edge" };
 
 const cors = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type, Authorization",
 };
 
 export default async function handler(req) {
-  if (req.method === "OPTIONS") return new Response(null, { status: 204, headers: cors });
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: cors });
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: cors });
+  }
+
+  // Friendly usage for GET requests in browser
+  if (req.method === "GET") {
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        message: "Este endpoint acepta POST.",
+        usage: {
+          preferred: {
+            method: "POST",
+            contentType: "multipart/form-data",
+            fields: { query: "string", image: "archivo opcional" },
+          },
+          alternative: {
+            method: "POST",
+            contentType: "application/json",
+            body: { query: "string" },
+          },
+        },
+      }),
+      { headers: { ...cors, "Content-Type": "application/json; charset=utf-8" } }
+    );
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405, headers: cors });
+  }
 
   try {
-    const form = await req.formData();
-    const query = (form.get("query") || "").toString().slice(0, 1000);
-    const file = form.get("image");
+    const contentType = (req.headers.get("content-type") || "").toLowerCase();
+
+    let query = "";
+    let file = null;
+
+    if (contentType.includes("application/json")) {
+      const data = await req.json();
+      query = (data?.query || "").toString().slice(0, 1000);
+      // Imagen no soportada vía JSON en este endpoint por simplicidad
+    } else if (contentType.includes("multipart/form-data")) {
+      const form = await req.formData();
+      query = (form.get("query") || "").toString().slice(0, 1000);
+      file = form.get("image");
+    } else if (contentType.includes("text/plain")) {
+      const txt = await req.text();
+      query = (txt || "").toString().slice(0, 1000);
+    } else {
+      return new Response(
+        JSON.stringify({ error: "Unsupported Media Type. Usa form-data o JSON." }),
+        { status: 415, headers: { ...cors, "Content-Type": "application/json; charset=utf-8" } }
+      );
+    }
 
     const parts = [];
     if (query) {
       parts.push({
         text:
-        `Rol: Eres un curador musical. Tarea: recomendar 3-5 artistas.
+          `Rol: Eres un curador musical. Tarea: recomendar 3-5 artistas.
         Contexto del usuario: ${query}
         Criterio: letras, estética/imagen, subgénero, época, similares.
-        Formato: lista breve con artista + por qué.`
+        Formato: lista breve con artista + por qué.`,
       });
     }
 
@@ -35,7 +83,19 @@ export default async function handler(req) {
       parts.push({ inlineData: { mimeType, data: base64 } });
     }
 
-    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+    if (parts.length === 0) {
+      return new Response(
+        JSON.stringify({ error: "Falta 'query' o 'image'." }),
+        { status: 400, headers: { ...cors, "Content-Type": "application/json; charset=utf-8" } }
+      );
+    }
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      return new Response("Falta configurar GEMINI_API_KEY", { status: 500, headers: cors });
+    }
+
+    const genAI = new GoogleGenerativeAI(apiKey);
     const model = genAI.getGenerativeModel({
       model: "gemini-1.5-flash",
       systemInstruction:


### PR DESCRIPTION
Add GET support and `application/json` POST handling to `api/query` to resolve "Method Not Allowed" errors and improve API usability.

The original endpoint only supported `POST` with `multipart/form-data`, leading to "Method Not Allowed" for browser GET requests and internal errors when `POST` requests were sent with `application/json`. This PR expands method and content-type support, and adds clearer error messages for better debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-b476d030-161c-4f65-baed-28fb92dc1221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b476d030-161c-4f65-baed-28fb92dc1221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

